### PR TITLE
fix: corregir build de TypeScript en Render

### DIFF
--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -17,7 +17,7 @@ services:
     
     # Build
     buildCommand: npm install && npm run build
-    startCommand: node dist/server.js
+    startCommand: NODE_ENV=production node dist/server.js
     
     # Node version
     envVars:
@@ -27,10 +27,6 @@ services:
       # Puerto (Render lo asigna automáticamente)
       - key: PORT
         value: 3000
-      
-      # Environment
-      - key: NODE_ENV
-        value: production
       
       # PostgreSQL (Neon)
       - key: DB_HOST


### PR DESCRIPTION
- Cambiar buildCommand a 'npm install' (necesita devDependencies)
- Mover NODE_ENV=production de envVars a startCommand
- Añadir .nvmrc con Node 20.18.0
- Start command: NODE_ENV=production node dist/server.js