### PR TITLE
4º

### DIFF
--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -16,7 +16,7 @@ services:
     branch: develop  # o 'main' según tu rama principal
     
     # Build
-    buildCommand: npm install && npm run build
+    buildCommand: npm install --production=false && npm run build
     startCommand: NODE_ENV=production node dist/server.js
     
     # Node version


### PR DESCRIPTION
 Updated the `buildCommand` to use `npm install --production=false` instead of the default, so that development dependencies are also installed during the build.